### PR TITLE
fix typo in DL example

### DIFF
--- a/cpt-dl.md
+++ b/cpt-dl.md
@@ -72,7 +72,7 @@ import cptdl as dl
 import datetime as dt
 template = dl.hindcasts['CanSIPSv2.PRCP']
 destination_file = "cansips_prcp.tsv" 
-args = { 
+kwargs = { 
   'fdate': dt.datetime.now(),
   'first_year': 1982, 
   'final_year': 2018, 


### PR DESCRIPTION
there is a small typo in the example for CPT-DL which means the examples don't work correctly - this fixes the problem 