### PR TITLE
Download links point to latest release instead of repo files

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -17,11 +17,11 @@ If Anaconda has installed correctly, the terminal prompt will be prefaced by ```
 
 ## PyCPT Quickstart:
 
-*Right click* to download the [notebook](https://raw.githubusercontent.com/iri-pycpt/notebooks/master/Operations/pycpt-operational.ipynb), as well as the conda environment file for your platform:
+Download the [notebook](https://github.com/iri-pycpt/notebooks/releases/latest/download/pycpt-operational.ipynb), as well as the conda environment file for your platform:
 
-- [Windows](https://raw.githubusercontent.com/iri-pycpt/notebooks/master/Operations/conda-win-64.lock)
-- [Linux](https://raw.githubusercontent.com/iri-pycpt/notebooks/master/Operations/conda-linux-64.lock)
-- [Mac](https://raw.githubusercontent.com/iri-pycpt/notebooks/master/Operations/conda-osx-64.lock)
+- [Windows](https://github.com/iri-pycpt/notebooks/releases/latest/download/conda-win-64.lock)
+- [Linux](https://github.com/iri-pycpt/notebooks/releases/latest/download/conda-linux-64.lock)
+- [Mac](https://github.com/iri-pycpt/notebooks/releases/latest/download/conda-osx-64.lock)
 
 and move the two files (notebook and environment file) to your working directory.
 


### PR DESCRIPTION
Release files have appropriate content-disposition headers so that they're downloaded by default, and saved with the intended filename. 